### PR TITLE
Removed references to non-existent things

### DIFF
--- a/npcs/villagers/monsieur_en_us.json
+++ b/npcs/villagers/monsieur_en_us.json
@@ -25,7 +25,7 @@
         {
             "lines": [
                 {
-                    "text": "My family had this Pokémon Center built when I was still a young man."
+                    "text": "My family had a Pokémon Center built when I was still a young man."
                 },
                 {
                     "text": "If you look closely, you will find our coat of arms carved somewhere on its walls."

--- a/npcs/villagers/schoolboy_en_us.json
+++ b/npcs/villagers/schoolboy_en_us.json
@@ -45,7 +45,7 @@
         {
             "lines": [
                 {
-                    "text": "We're learning about Hoenn in geography class."
+                    "text": "We're learning about a distant region in geography class."
                 },
                 {
                     "text": "There are lots of volcanoes all over! Awesome!"
@@ -58,7 +58,7 @@
                     "text": "My teacher's going to take us to a field trip next month!"
                 },
                 {
-                    "text": "We'll visit a Pokémon daycare. Maybe we'll see cute baby Pokémon?"
+                    "text": "We'll visit a Pokémon ranch. Maybe we'll see cute baby Pokémon?"
                 }
             ]
         }

--- a/npcs/villagers/schoolgirl_en_us.json
+++ b/npcs/villagers/schoolgirl_en_us.json
@@ -25,7 +25,7 @@
         {
             "lines": [
                 {
-                    "text": "We're learning a lot of interesting stuff at school, but I can't wait to become a trainer."
+                    "text": "We're learning a lot of interesting stuff at school, but I can't wait to become a Trainer."
                 },
                 {
                     "text": "The next best thing is the summer activities with the Rangers!"
@@ -39,16 +39,6 @@
                 },
                 {
                     "text": "And then my friends are going to spoil it before I can watch a rerun..."
-                }
-            ]
-        },
-        {
-            "lines": [
-                {
-                    "text": "If I have 2000 PokéDollars and Poké Balls are worth 200 PokéDollars each, how many Poké Balls can I get?"
-                },
-                {
-                    "text": "Eleven! It was a trick question, because I also get the free Premier Ball!"
                 }
             ]
         },


### PR DESCRIPTION
-PokéMart one is really good, but I’ll have to remove it for the time being as there aren’t any PokéMarts in Pixelmon and there’s no way to salvage it with Pixelmon-relevant terms.
-Also modified references to Pokémon regions and daycares.